### PR TITLE
Update cert version to be standards compliant

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ def generate_keypair(signer = nil, serial = nil, subj = nil)
   cert.not_after  = Time.now + 365 * 24 * 360
   cert.public_key = private_key.public_key
   cert.serial     = serial
-  cert.version    = 3
+  cert.version    = 2
 
   ef = OpenSSL::X509::ExtensionFactory.new
   ef.subject_certificate = cert


### PR DESCRIPTION
By setting the `version` parameter to 3 it actually created "v4" certificate. The documentation indicates that for whatever reason the version parameter creates a certificate with version+1.

http://docs.ruby-lang.org/en/2.3.0/OpenSSL/X509/Certificate.html#class-OpenSSL::X509::Certificate-label-Creating+a+root+CA+certificate+and+an+end-entity+certificate
